### PR TITLE
fix: missing plenary.nvim plugin

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -53,6 +53,7 @@ Plug 'ryanoasis/vim-devicons'
 Plug 'saadparwaiz1/cmp_luasnip'
 Plug 'scrooloose/nerdtree'
 Plug 'zivyangll/git-blame.vim'
+Plug 'nvim-lua/plenary.nvim'
 
 call plug#end()
 


### PR DESCRIPTION
Faltaba el plugin "plenary.nvim" en el `nvim/init.vim`
<img width="698" alt="CleanShot 2022-10-23 at 20 47 00@2x" src="https://user-images.githubusercontent.com/6422177/197410190-2290ce18-d3d6-4853-b62c-390f91a5374d.png">
